### PR TITLE
fix: Avoid Refreshing after Audit Status Change; Fixed Workflow Sorting Issue in Audit Page

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2887,7 +2887,6 @@
 	"audit.status.declined": "Declined",
 	"audit.submission.result.success": "Audit result submitted",
 	"audit.submission.request.success": "Audit request submitted",
-	"audit.submission.refresh": "Refresh page to update",
 	"mfa.setup.invalidAuthenticatorCode": "{code} is not a valid number",
 	"mfa.setup.invalidCode": "Two-factor code failed. Please try again.",
 	"mfa.code.modal.title": "Two-factor authentication",

--- a/packages/frontend/@n8n/i18n/src/locales/zh.json
+++ b/packages/frontend/@n8n/i18n/src/locales/zh.json
@@ -2809,7 +2809,6 @@
 	"audit.status.declined": "已拒绝",
 	"audit.submission.result.success": "审阅结果已提交",
 	"audit.submission.request.success": "审阅请求已提交",
-	"audit.submission.refresh": "刷新页面以更新",
 	"mfa.setup.invalidAuthenticatorCode": "{code} 不是有效的数字",
 	"mfa.setup.invalidCode": "双重验证失败。请重试。",
 	"mfa.code.modal.title": "双重验证",

--- a/packages/frontend/editor-ui/src/api/workflows.ts
+++ b/packages/frontend/editor-ui/src/api/workflows.ts
@@ -208,7 +208,6 @@ export async function updateWorkflowAuditStatus(
 	workflowId: string,
 	status: WorkflowStatus,
 ) {
-	console.log('status in workflows.ts. submitting request: ', status);
 	return await makeRestApiRequest(context, 'PATCH', `/workflows/${workflowId}/audit-status`, {
 		status,
 	});

--- a/packages/frontend/editor-ui/src/components/AuditButtons.vue
+++ b/packages/frontend/editor-ui/src/components/AuditButtons.vue
@@ -13,24 +13,24 @@ const props = defineProps<{
 	audit_status: WorkflowStatus;
 }>();
 
+const emit = defineEmits<{
+	'audit-status-updated': [];
+}>();
+
 function showAuditFinishedToast() {
 	let toastTitle = locale.baseText('audit.submission.result.success');
-	let toastText = locale.baseText('audit.submission.refresh');
 
 	toast.showMessage({
 		title: toastTitle,
-		message: toastText,
 		type: 'success',
 	});
 }
 
 function showAuditSubmittedToast() {
 	let toastTitle = locale.baseText('audit.submission.request.success');
-	let toastText = locale.baseText('audit.submission.refresh');
 
 	toast.showMessage({
 		title: toastTitle,
-		message: toastText,
 		type: 'success',
 	});
 }
@@ -38,15 +38,18 @@ function showAuditSubmittedToast() {
 async function onApproveWorkflow() {
 	await workflowsStore.updateWorkflowAuditStatus(props.workflow_id, 'approved' as WorkflowStatus);
 	showAuditFinishedToast();
+	emit('audit-status-updated');
 }
 
 async function onDeclineWorkflow() {
 	await workflowsStore.updateWorkflowAuditStatus(props.workflow_id, 'declined' as WorkflowStatus);
 	showAuditFinishedToast();
+	emit('audit-status-updated');
 }
 async function onSubmitWorkflowForAudit() {
 	await workflowsStore.updateWorkflowAuditStatus(props.workflow_id, 'submitted' as WorkflowStatus);
 	showAuditSubmittedToast();
+	emit('audit-status-updated');
 }
 </script>
 

--- a/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
@@ -78,7 +78,6 @@ const hideMenuBar = computed(() =>
 	Boolean(activeNode.value && activeNode.value.type !== STICKY_NODE_TYPE),
 );
 const workflow = computed(() => workflowsStore.workflow);
-console.log('active at setup in MainHeader.vue:', workflow.value.active);
 const workflowId = computed(() =>
 	String(router.currentRoute.value.params.name || workflowsStore.workflowId),
 );

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -71,6 +71,7 @@ const emit = defineEmits<{
 			sharedWithProjects?: ProjectSharingData[];
 		},
 	];
+	'workflow:status-updated': [];
 }>();
 
 const toast = useToast();
@@ -525,7 +526,11 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 					data-test-id="workflow-card-activator"
 					@update:workflow-active="emitWorkflowActiveToggle"
 				/>
-				<AuditButtons :workflow_id="data.id" :audit_status="data.status" />
+				<AuditButtons
+					:workflow_id="data.id"
+					:audit_status="data.status"
+					@audit-status-updated="$emit('workflow:status-updated')"
+				/>
 				<n8n-action-toggle
 					:actions="actions"
 					theme="dark"

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -608,7 +608,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	async function fetchWorkflow(id: string): Promise<IWorkflowDb> {
 		const workflowData = await workflowsApi.getWorkflow(rootStore.restApiContext, id);
 		addWorkflow(workflowData);
-		console.log('workflow data in workflows.store.ts fetchWorkflow():', workflowData);
 		return workflowData;
 	}
 
@@ -1713,7 +1712,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		data: IWorkflowDataUpdate,
 		forceSave = false,
 	): Promise<IWorkflowDb> {
-		console.log('data in update workflow: ', data);
 		if (data.settings === null) {
 			data.settings = undefined;
 		}
@@ -1742,10 +1740,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowId: string,
 		status: WorkflowStatus,
 	): Promise<void> {
-		console.log('submitting request in workflows.store.ts: ', status);
 		await workflowsApi.updateWorkflowAuditStatus(rootStore.restApiContext, workflowId, status);
 		setWorkflowAuditStatus(status);
-		console.log('finished request in workflows.store.ts');
 	}
 
 	async function runWorkflow(startRunData: IStartRunData): Promise<IExecutionPushResponse> {

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -456,7 +456,6 @@ async function fetchAndSetProject(projectId: string) {
 async function initializeWorkspaceForExistingWorkflow(id: string) {
 	try {
 		const workflowData = await workflowsStore.fetchWorkflow(id);
-		console.log('workflow data intialize workspace for existing workflow', workflowData);
 
 		openWorkflow(workflowData);
 

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -290,7 +290,6 @@ const workflowListResources = computed<Resource[]>(() => {
 				parentFolder: resource.parentFolder,
 			} satisfies FolderResource;
 		} else {
-			console.log('resource status', resource.status);
 			return {
 				resourceType: 'workflow',
 				id: resource.id,
@@ -473,7 +472,6 @@ const initialize = async () => {
 	]);
 	breadcrumbsLoading.value = false;
 	workflowsAndFolders.value = resourcesPage;
-	console.log('resourcesPage', resourcesPage);
 	loading.value = false;
 };
 
@@ -549,7 +547,6 @@ const fetchWorkflows = async () => {
 		// Toggle ownership cards visibility only after we have fetched the workflows
 		showCardsBadge.value =
 			projectPages.isOverviewSubPage || projectPages.isSharedSubPage || filters.value.search !== '';
-		console.log(workflowsAndFolders);
 
 		return fetchedResources;
 	} catch (error) {
@@ -1707,6 +1704,7 @@ const onNameSubmit = async ({
 					:show-ownership-badge="showCardsBadge"
 					data-target="workflow"
 					@click:tag="onClickTag"
+					@workflow:status-updated="fetchWorkflows"
 					@workflow:deleted="refreshWorkflows"
 					@workflow:archived="refreshWorkflows"
 					@workflow:unarchived="refreshWorkflows"


### PR DESCRIPTION
I made it such that users do not need to refresh the webpage when they submit their audit requests and sending audit results. 
I fixed the issue such that the sorting of workflows in audit page works as intended. 
I deleted console.log statements. 