### PR TITLE
feat: Share database mongodb

### DIFF
--- a/packages/cli/src/constants/credentials.ts
+++ b/packages/cli/src/constants/credentials.ts
@@ -4,6 +4,8 @@ export const SHARED_CREDENTIAL_TYPES = [
 	'anthropicApi',
 	'azureOpenAiApi',
 	'googlePalmApi',
+	'postgres',
+	'mongoDb',
 ] as const;
 
 export type CredentialType = (typeof SHARED_CREDENTIAL_TYPES)[number];

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
@@ -20,7 +20,7 @@ import { i18n } from '@n8n/i18n';
 import { getCredentialOnlyNodeType } from '@/utils/credentialOnlyNodes';
 import { formatTriggerActionName } from '../utils';
 import { useEvaluationStore } from '@/stores/evaluation.store.ee';
-import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
+import { filterNodeOperationsByUserRole } from '@/utils/nodeOperationFilters';
 
 const PLACEHOLDER_RECOMMENDED_ACTION_KEY = 'placeholder_recommended';
 

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
@@ -20,6 +20,7 @@ import { i18n } from '@n8n/i18n';
 import { getCredentialOnlyNodeType } from '@/utils/credentialOnlyNodes';
 import { formatTriggerActionName } from '../utils';
 import { useEvaluationStore } from '@/stores/evaluation.store.ee';
+import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
 
 const PLACEHOLDER_RECOMMENDED_ACTION_KEY = 'placeholder_recommended';
 
@@ -84,7 +85,13 @@ function operationsCategory(nodeTypeDescription: INodeTypeDescription): ActionTy
 
 	if (!matchedProperty?.options) return [];
 
-	const filteredOutItems = (matchedProperty.options as INodePropertyOptions[]).filter(
+	// Apply user role-based filtering before processing the operations
+	const filteredProperty = filterNodeOperationsByUserRole(
+		nodeTypeDescription.name,
+		matchedProperty,
+	);
+
+	const filteredOutItems = (filteredProperty.options as INodePropertyOptions[]).filter(
 		(categoryItem: INodePropertyOptions) => !['*', '', ' '].includes(categoryItem.name),
 	);
 
@@ -93,10 +100,10 @@ function operationsCategory(nodeTypeDescription: INodeTypeDescription): ActionTy
 		actionKey: item.value as string,
 		displayName: item.action ?? startCase(item.name),
 		description: item.description ?? '',
-		displayOptions: matchedProperty.displayOptions,
+		displayOptions: filteredProperty.displayOptions,
 		outputConnectionType: item.outputConnectionType,
 		values: {
-			[matchedProperty.name]: matchedProperty.type === 'multiOptions' ? [item.value] : item.value,
+			[filteredProperty.name]: filteredProperty.type === 'multiOptions' ? [item.value] : item.value,
 		},
 	}));
 
@@ -229,7 +236,13 @@ function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTy
 
 				if (!operations?.options) return;
 
-				const items = ((operations.options as INodePropertyOptions[]) || []).map(
+				// Apply user role-based filtering to operations
+				const filteredOperations = filterNodeOperationsByUserRole(
+					nodeTypeDescription.name,
+					operations,
+				);
+
+				const items = ((filteredOperations.options as INodePropertyOptions[]) || []).map(
 					(operationOption) => {
 						const displayName =
 							operationOption.action ?? `${resourceOption.name} ${startCase(operationOption.name)}`;
@@ -238,7 +251,7 @@ function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTy
 						// if the resource has only one option
 						const displayOptions = isSingleResource
 							? { show: { resource: [options[0]?.value] } }
-							: operations?.displayOptions;
+							: filteredOperations?.displayOptions;
 
 						return {
 							...getNodeTypeBase(
@@ -250,7 +263,7 @@ function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTy
 							displayOptions,
 							values: {
 								operation:
-									operations?.type === 'multiOptions'
+									filteredOperations?.type === 'multiOptions'
 										? [operationOption.value]
 										: operationOption.value,
 							},

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -51,6 +51,7 @@ import { importCurlEventBus, ndvEventBus } from '@/event-bus';
 import { ProjectTypes } from '@/types/projects.types';
 import { updateDynamicConnections } from '@/utils/nodeSettingsUtils';
 import FreeAiCreditsCallout from '@/components/FreeAiCreditsCallout.vue';
+import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
 
 const props = withDefaults(
 	defineProps<{
@@ -199,7 +200,13 @@ const parameters = computed(() => {
 		return [];
 	}
 
-	return props.nodeType?.properties ?? [];
+	// Apply user role-based filtering to node parameters
+	const nodeTypeProperties = props.nodeType?.properties ?? [];
+	const nodeTypeName = props.nodeType?.name || '';
+
+	return nodeTypeProperties.map((parameter) =>
+		filterNodeOperationsByUserRole(nodeTypeName, parameter),
+	);
 });
 
 const parametersSetting = computed(() => parameters.value.filter((item) => item.isNodeSetting));

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -51,7 +51,7 @@ import { importCurlEventBus, ndvEventBus } from '@/event-bus';
 import { ProjectTypes } from '@/types/projects.types';
 import { updateDynamicConnections } from '@/utils/nodeSettingsUtils';
 import FreeAiCreditsCallout from '@/components/FreeAiCreditsCallout.vue';
-import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
+import { filterNodeOperationsByUserRole } from '@/utils/nodeOperationFilters';
 
 const props = withDefaults(
 	defineProps<{

--- a/packages/frontend/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputList.vue
@@ -40,6 +40,7 @@ import { get, set } from 'lodash-es';
 import { N8nIcon, N8nIconButton, N8nInputLabel, N8nNotice, N8nText } from '@n8n/design-system';
 import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
+import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
 
 const LazyFixedCollectionParameter = defineAsyncComponent(
 	async () => await import('./FixedCollectionParameter.vue'),
@@ -109,7 +110,13 @@ const nodeType = computed(() => {
 const filteredParameters = computedWithControl(
 	[() => props.parameters, () => props.nodeValues] as WatchSource[],
 	() => {
-		const parameters = props.parameters.filter((parameter: INodeProperties) =>
+		// Apply user role-based filtering first
+		const nodeTypeName = nodeType.value?.name || '';
+		const roleFilteredParameters = props.parameters.map((parameter) =>
+			filterNodeOperationsByUserRole(nodeTypeName, parameter),
+		);
+
+		const parameters = roleFilteredParameters.filter((parameter: INodeProperties) =>
 			displayNodeParameter(parameter),
 		);
 

--- a/packages/frontend/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputList.vue
@@ -40,7 +40,7 @@ import { get, set } from 'lodash-es';
 import { N8nIcon, N8nIconButton, N8nInputLabel, N8nNotice, N8nText } from '@n8n/design-system';
 import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
-import { filterNodeOperationsByUserRole } from '@/utils/rbacUtils';
+import { filterNodeOperationsByUserRole } from '@/utils/nodeOperationFilters';
 
 const LazyFixedCollectionParameter = defineAsyncComponent(
 	async () => await import('./FixedCollectionParameter.vue'),

--- a/packages/frontend/editor-ui/src/constants/credentials.ts
+++ b/packages/frontend/editor-ui/src/constants/credentials.ts
@@ -4,6 +4,8 @@ export const SHARED_CREDENTIAL_TYPES = [
 	'anthropicApi',
 	'azureOpenAiApi',
 	'googlePalmApi',
+	'postgres',
+	'mongoDb',
 ] as const;
 
 export type CredentialType = (typeof SHARED_CREDENTIAL_TYPES)[number];

--- a/packages/frontend/editor-ui/src/utils/nodeOperationFilters.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeOperationFilters.ts
@@ -1,0 +1,62 @@
+import type { INodePropertyOptions, INodeProperties } from 'n8n-workflow';
+import { useUsersStore } from '@/stores/users.store';
+
+/**
+ * Filter node operation options based on user role
+ * Hide delete operations for member users in MongoDB and PostgreSQL nodes
+ * This function filters both the operation options and their associated actions
+ * to ensure member users cannot see or access delete functionality
+ */
+export function filterNodeOperationsByUserRole(
+	nodeType: string,
+	parameter: INodeProperties,
+): INodeProperties {
+	const usersStore = useUsersStore();
+	const currentUser = usersStore.currentUser;
+
+	// Only apply filtering to operation parameters
+	if (parameter.name !== 'operation' || parameter.type !== 'options') {
+		return parameter;
+	}
+
+	// Only apply to MongoDB and PostgreSQL nodes
+	const restrictedNodeTypes = ['n8n-nodes-base.mongoDb', 'n8n-nodes-base.postgres'];
+	if (!restrictedNodeTypes.includes(nodeType)) {
+		return parameter;
+	}
+
+	// Only restrict for member users - owners and admins can see all operations
+	if (!currentUser || currentUser.role !== 'global:member') {
+		return parameter;
+	}
+
+	// Filter out delete operations for member users
+	const filteredOptions = (parameter.options as INodePropertyOptions[]).filter((option) => {
+		// For MongoDB: hide 'delete' operation and its action
+		if (nodeType === 'n8n-nodes-base.mongoDb' && option.value === 'delete') {
+			return false;
+		}
+		// For PostgreSQL: hide 'deleteTable' operation and its action
+		if (nodeType === 'n8n-nodes-base.postgres' && option.value === 'deleteTable') {
+			return false;
+		}
+		return true;
+	});
+
+	// Return a modified parameter with filtered options
+	return {
+		...parameter,
+		options: filteredOptions,
+	};
+}
+
+/**
+ * Check if current user can perform delete operations
+ */
+export function canPerformDeleteOperations(): boolean {
+	const usersStore = useUsersStore();
+	const currentUser = usersStore.currentUser;
+
+	// Owners and admins can perform delete operations, members cannot
+	return currentUser?.role === 'global:owner' || currentUser?.role === 'global:admin';
+}

--- a/packages/frontend/editor-ui/src/utils/rbacUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/rbacUtils.ts
@@ -1,5 +1,7 @@
 import type { RouteLocationNormalized } from 'vue-router';
 import type { Resource } from '@n8n/permissions';
+import type { INodePropertyOptions, INodeProperties } from 'n8n-workflow';
+import { useUsersStore } from '@/stores/users.store';
 
 export function inferProjectIdFromRoute(to: RouteLocationNormalized): string {
 	const routeParts = to.path.split('/');
@@ -33,4 +35,64 @@ export function inferResourceTypeFromRoute(to: RouteLocationNormalized): Resourc
 
 export function inferResourceIdFromRoute(to: RouteLocationNormalized): string | undefined {
 	return (to.params.id as string | undefined) ?? (to.params.name as string | undefined);
+}
+
+/**
+ * Filter node operation options based on user role
+ * Hide delete operations for member users in MongoDB and PostgreSQL nodes
+ * This function filters both the operation options and their associated actions
+ * to ensure member users cannot see or access delete functionality
+ */
+export function filterNodeOperationsByUserRole(
+	nodeType: string,
+	parameter: INodeProperties,
+): INodeProperties {
+	const usersStore = useUsersStore();
+	const currentUser = usersStore.currentUser;
+
+	// Only apply filtering to operation parameters
+	if (parameter.name !== 'operation' || parameter.type !== 'options') {
+		return parameter;
+	}
+
+	// Only apply to MongoDB and PostgreSQL nodes
+	const restrictedNodeTypes = ['n8n-nodes-base.mongoDb', 'n8n-nodes-base.postgres'];
+	if (!restrictedNodeTypes.includes(nodeType)) {
+		return parameter;
+	}
+
+	// Only restrict for member users - owners and admins can see all operations
+	if (!currentUser || currentUser.role !== 'global:member') {
+		return parameter;
+	}
+
+	// Filter out delete operations for member users
+	const filteredOptions = (parameter.options as INodePropertyOptions[]).filter((option) => {
+		// For MongoDB: hide 'delete' operation and its action
+		if (nodeType === 'n8n-nodes-base.mongoDb' && option.value === 'delete') {
+			return false;
+		}
+		// For PostgreSQL: hide 'deleteTable' operation and its action
+		if (nodeType === 'n8n-nodes-base.postgres' && option.value === 'deleteTable') {
+			return false;
+		}
+		return true;
+	});
+
+	// Return a modified parameter with filtered options
+	return {
+		...parameter,
+		options: filteredOptions,
+	};
+}
+
+/**
+ * Check if current user can perform delete operations
+ */
+export function canPerformDeleteOperations(): boolean {
+	const usersStore = useUsersStore();
+	const currentUser = usersStore.currentUser;
+
+	// Owners and admins can perform delete operations, members cannot
+	return currentUser?.role === 'global:owner' || currentUser?.role === 'global:admin';
 }

--- a/packages/frontend/editor-ui/src/utils/rbacUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/rbacUtils.ts
@@ -1,7 +1,5 @@
 import type { RouteLocationNormalized } from 'vue-router';
 import type { Resource } from '@n8n/permissions';
-import type { INodePropertyOptions, INodeProperties } from 'n8n-workflow';
-import { useUsersStore } from '@/stores/users.store';
 
 export function inferProjectIdFromRoute(to: RouteLocationNormalized): string {
 	const routeParts = to.path.split('/');
@@ -37,62 +35,6 @@ export function inferResourceIdFromRoute(to: RouteLocationNormalized): string | 
 	return (to.params.id as string | undefined) ?? (to.params.name as string | undefined);
 }
 
-/**
- * Filter node operation options based on user role
- * Hide delete operations for member users in MongoDB and PostgreSQL nodes
- * This function filters both the operation options and their associated actions
- * to ensure member users cannot see or access delete functionality
- */
-export function filterNodeOperationsByUserRole(
-	nodeType: string,
-	parameter: INodeProperties,
-): INodeProperties {
-	const usersStore = useUsersStore();
-	const currentUser = usersStore.currentUser;
-
-	// Only apply filtering to operation parameters
-	if (parameter.name !== 'operation' || parameter.type !== 'options') {
-		return parameter;
-	}
-
-	// Only apply to MongoDB and PostgreSQL nodes
-	const restrictedNodeTypes = ['n8n-nodes-base.mongoDb', 'n8n-nodes-base.postgres'];
-	if (!restrictedNodeTypes.includes(nodeType)) {
-		return parameter;
-	}
-
-	// Only restrict for member users - owners and admins can see all operations
-	if (!currentUser || currentUser.role !== 'global:member') {
-		return parameter;
-	}
-
-	// Filter out delete operations for member users
-	const filteredOptions = (parameter.options as INodePropertyOptions[]).filter((option) => {
-		// For MongoDB: hide 'delete' operation and its action
-		if (nodeType === 'n8n-nodes-base.mongoDb' && option.value === 'delete') {
-			return false;
-		}
-		// For PostgreSQL: hide 'deleteTable' operation and its action
-		if (nodeType === 'n8n-nodes-base.postgres' && option.value === 'deleteTable') {
-			return false;
-		}
-		return true;
-	});
-
-	// Return a modified parameter with filtered options
-	return {
-		...parameter,
-		options: filteredOptions,
-	};
-}
-
-/**
- * Check if current user can perform delete operations
- */
-export function canPerformDeleteOperations(): boolean {
-	const usersStore = useUsersStore();
-	const currentUser = usersStore.currentUser;
-
-	// Owners and admins can perform delete operations, members cannot
-	return currentUser?.role === 'global:owner' || currentUser?.role === 'global:admin';
-}
+// Note: Node operation filtering functions have been moved to nodeOperationFilters.ts
+// Import them from there if needed:
+// import { filterNodeOperationsByUserRole, canPerformDeleteOperations } from './nodeOperationFilters';


### PR DESCRIPTION
## Shared
Authentication for mongoDB and postgres databases

## Changes
['n8n-nodes-base.mongoDb', 'n8n-nodes-base.postgres'];
Hide delete in operation (for member)
Hide delete in generated actions (for member)

## Avoid duplicate names
For mongoDB, modify the backend of collection, insert, find, and update to add the prefix of userID
![img_v3_02nc_e6126568-4801-4aae-b029-33b386a5691g](https://github.com/user-attachments/assets/cab63c3e-464c-4b4a-999b-773d6cd9ed79)
