### PR TITLE
fix(core): Fix the Bug where People cannot Perform Certain Actions when Using Chinese Language

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/zh.json
+++ b/packages/frontend/@n8n/i18n/src/locales/zh.json
@@ -3208,5 +3208,16 @@
 	"workflows.filters.showArchived": "显示已归档工作流",
 	"workflows.item.archive": "归档",
 	"workflows.item.archived": "已归档",
-	"workflows.item.unarchive": "取消归档"
+	"workflows.item.unarchive": "取消归档",
+	"n8n-nodes-base.credentials.openAiApi": {
+		"url": {
+			"displayName": "基础url"
+		},
+		"apiKey": {
+			"displayName": "api密钥"
+		},
+		"organizationId": {
+			"displayName": "组织ID (organization ID)（选填）"
+		}
+	}
 }

--- a/packages/frontend/@n8n/i18n/src/locales/zh.json
+++ b/packages/frontend/@n8n/i18n/src/locales/zh.json
@@ -1820,7 +1820,7 @@
 	"settings.communityNodes.installModal.description": "在 npm 公共注册表中查找并安装社区节点。",
 	"settings.communityNodes.browseButton.label": "浏览",
 	"settings.communityNodes.installModal.packageName.label": "npm 包名称",
-	"settings.communityNodes.installModal.packageName.tooltip": "<img src='/static/community_package_tooltip_img.png'/><p>这是 <a href='{npmURL}'>npmjs.com</a> 上的包名</p><p>指定版本可在后面添加 @，如 <code>package-name@0.15.0</code></p>",
+	"settings.communityNodes.installModal.packageName.tooltip": "<img src='/static/community_package_tooltip_img.png'/><p>这是 <a href='{npmURL}'>npmjs.com</a> 上的包名</p><p>指定版本可在后面添加 {'@'}，如 <code>package-name{'@'}0.15.0</code></p>",
 	"settings.communityNodes.installModal.packageName.placeholder": "例如：n8n-nodes-chatwork",
 	"settings.communityNodes.installModal.checkbox.label": "我理解安装来自公共源的未验证代码存在风险。",
 	"settings.communityNodes.installModal.installButton.label": "安装",

--- a/packages/frontend/editor-ui/src/components/CommunityPackageInstallModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageInstallModal.vue
@@ -9,7 +9,7 @@ import {
 } from '@/constants';
 import { useToast } from '@/composables/useToast';
 import { useCommunityNodesStore } from '@/stores/communityNodes.store';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
@@ -27,6 +27,41 @@ const packageName = ref('');
 const userAgreed = ref(false);
 const checkboxWarning = ref(false);
 const infoTextErrorMessage = ref('');
+
+const modalTitle = computed(() => i18n.baseText('settings.communityNodes.installModal.title'));
+const modalDescription = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.description'),
+);
+const moreInfoText = computed(() => i18n.baseText('generic.moreInfo'));
+const browseButtonLabel = computed(() =>
+	i18n.baseText('settings.communityNodes.browseButton.label'),
+);
+const packageNameLabel = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.packageName.label'),
+);
+const packageNameTooltip = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.packageName.tooltip', {
+		interpolate: { npmURL: NPM_KEYWORD_SEARCH_URL },
+	}),
+);
+const packageNamePlaceholder = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.packageName.placeholder'),
+);
+const checkboxLabel = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.checkbox.label'),
+);
+const installButtonLabel = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.installButton.label'),
+);
+const installButtonLoadingLabel = computed(() =>
+	i18n.baseText('settings.communityNodes.installModal.installButton.label.loading'),
+);
+const installSuccessMessage = computed(() =>
+	i18n.baseText('settings.communityNodes.messages.install.success'),
+);
+const installErrorMessage = computed(() =>
+	i18n.baseText('settings.communityNodes.messages.install.error'),
+);
 
 const openNPMPage = () => {
 	telemetry.track('user clicked cnr browse button', { source: 'cnr install modal' });
@@ -49,14 +84,14 @@ const onInstallClick = async () => {
 			loading.value = false;
 			modalBus.emit('close');
 			toast.showMessage({
-				title: i18n.baseText('settings.communityNodes.messages.install.success'),
+				title: installSuccessMessage.value,
 				type: 'success',
 			});
 		} catch (error) {
 			if (error.httpStatusCode && error.httpStatusCode === 400) {
 				infoTextErrorMessage.value = error.message;
 			} else {
-				toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
+				toast.showError(error, installErrorMessage.value);
 			}
 		} finally {
 			loading.value = false;
@@ -91,7 +126,7 @@ const onLearnMoreLinkClick = () => {
 	<Modal
 		width="540px"
 		:name="COMMUNITY_PACKAGE_INSTALL_MODAL_KEY"
-		:title="i18n.baseText('settings.communityNodes.installModal.title')"
+		:title="modalTitle"
 		:event-bus="modalBus"
 		:center="true"
 		:before-close="onModalClose"
@@ -101,15 +136,15 @@ const onLearnMoreLinkClick = () => {
 			<div :class="[$style.descriptionContainer, 'p-s']">
 				<div>
 					<n8n-text>
-						{{ i18n.baseText('settings.communityNodes.installModal.description') }}
+						{{ modalDescription }}
 					</n8n-text>
 					{{ ' ' }}
 					<n8n-link :to="COMMUNITY_NODES_INSTALLATION_DOCS_URL" @click="onMoreInfoTopClick">
-						{{ i18n.baseText('generic.moreInfo') }}
+						{{ moreInfoText }}
 					</n8n-link>
 				</div>
 				<n8n-button
-					:label="i18n.baseText('settings.communityNodes.browseButton.label')"
+					:label="browseButtonLabel"
 					icon="external-link-alt"
 					:class="$style.browseButton"
 					@click="openNPMPage"
@@ -118,12 +153,8 @@ const onLearnMoreLinkClick = () => {
 			<div :class="[$style.formContainer, 'mt-m']">
 				<n8n-input-label
 					:class="$style.labelTooltip"
-					:label="i18n.baseText('settings.communityNodes.installModal.packageName.label')"
-					:tooltip-text="
-						i18n.baseText('settings.communityNodes.installModal.packageName.tooltip', {
-							interpolate: { npmURL: NPM_KEYWORD_SEARCH_URL },
-						})
-					"
+					:label="packageNameLabel"
+					:tooltip-text="packageNameTooltip"
 				>
 					<n8n-input
 						v-model="packageName"
@@ -131,9 +162,7 @@ const onLearnMoreLinkClick = () => {
 						type="text"
 						data-test-id="package-name-input"
 						:maxlength="214"
-						:placeholder="
-							i18n.baseText('settings.communityNodes.installModal.packageName.placeholder')
-						"
+						:placeholder="packageNamePlaceholder"
 						:required="true"
 						:disabled="loading"
 						@blur="onInputBlur"
@@ -153,11 +182,9 @@ const onLearnMoreLinkClick = () => {
 					data-test-id="user-agreement-checkbox"
 					@update:model-value="onCheckboxChecked"
 				>
-					<n8n-text>
-						{{ i18n.baseText('settings.communityNodes.installModal.checkbox.label') }} </n8n-text
-					><br />
+					<n8n-text> {{ checkboxLabel }} </n8n-text><br />
 					<n8n-link :to="COMMUNITY_NODES_RISKS_DOCS_URL" @click="onLearnMoreLinkClick">{{
-						i18n.baseText('generic.moreInfo')
+						moreInfoText
 					}}</n8n-link>
 				</el-checkbox>
 			</div>
@@ -166,11 +193,7 @@ const onLearnMoreLinkClick = () => {
 			<n8n-button
 				:loading="loading"
 				:disabled="!userAgreed || packageName === '' || loading"
-				:label="
-					loading
-						? i18n.baseText('settings.communityNodes.installModal.installButton.label.loading')
-						: i18n.baseText('settings.communityNodes.installModal.installButton.label')
-				"
+				:label="loading ? installButtonLoadingLabel : installButtonLabel"
 				size="large"
 				float="right"
 				data-test-id="install-community-package-button"

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -20,7 +20,7 @@ import {
 	NEW_ASSISTANT_SESSION_MODAL,
 } from '@/constants';
 import type { PermissionsRecord } from '@/permissions';
-import { addCredentialTranslation } from '@n8n/i18n';
+import { addCredentialTranslation, i18nInstance } from '@n8n/i18n';
 import { useCredentialsStore } from '@/stores/credentials.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -88,14 +88,27 @@ onBeforeMount(async () => {
 
 	if (i18n.exists(key)) return;
 
-	const credTranslation = await credentialsStore.getCredentialTranslation(
-		props.credentialType.name,
-	);
+	if (rootStore.defaultLocale === 'zh') {
+		const zhMessages = i18nInstance.global.messages.zh as any;
+		const credentialTranslation =
+			zhMessages[`n8n-nodes-base.credentials.${props.credentialType.name}`];
 
-	addCredentialTranslation(
-		{ [props.credentialType.name]: credTranslation },
-		rootStore.defaultLocale,
-	);
+		if (credentialTranslation) {
+			addCredentialTranslation(
+				{ [props.credentialType.name]: credentialTranslation },
+				rootStore.defaultLocale,
+			);
+		}
+	} else {
+		const credTranslation = await credentialsStore.getCredentialTranslation(
+			props.credentialType.name,
+		);
+
+		addCredentialTranslation(
+			{ [props.credentialType.name]: credTranslation },
+			rootStore.defaultLocale,
+		);
+	}
 });
 
 const appName = computed(() => {
@@ -128,7 +141,6 @@ const documentationUrl = computed(() => {
 		url = new URL(docUrl);
 		if (url.hostname !== DOCS_DOMAIN) return docUrl;
 	} else {
-		// Don't show documentation link for community nodes if the URL is not an absolute path
 		if (isCommunityNode) return '';
 		else url = new URL(`${BUILTIN_CREDENTIALS_DOCS_URL}${docUrl}/`);
 	}


### PR DESCRIPTION
Fixed the Bug where People cannot Add Credentials when Using Chinese n8n Version. The complicit lies in how the i18n texts are translated in the credential webpages. 

Fixed the bug where people cannot install and add community nodes when using Chinese n8n version. The complicit lies in how the webpage is rendered: i18n should load dynamically in community nodes view, but for some reason it is static. So I added computed = () => {} to make it dynamic. 


