### PR TITLE
feat(core): Remove questionnaire modal from UI

### DIFF
--- a/packages/frontend/editor-ui/src/components/Modals.vue
+++ b/packages/frontend/editor-ui/src/components/Modals.vue
@@ -12,7 +12,6 @@ import {
 	DELETE_USER_MODAL_KEY,
 	DUPLICATE_MODAL_KEY,
 	INVITE_USER_MODAL_KEY,
-	PERSONALIZATION_MODAL_KEY,
 	TAGS_MANAGER_MODAL_KEY,
 	ANNOTATION_TAGS_MANAGER_MODAL_KEY,
 	NPS_SURVEY_MODAL_KEY,
@@ -52,7 +51,6 @@ import InviteUsersModal from '@/components/InviteUsersModal.vue';
 import CredentialsSelectModal from '@/components/CredentialsSelectModal.vue';
 import DuplicateWorkflowDialog from '@/components/DuplicateWorkflowDialog.vue';
 import ModalRoot from '@/components/ModalRoot.vue';
-import PersonalizationModal from '@/components/PersonalizationModal.vue';
 import WorkflowTagsManager from '@/components/TagsManager/WorkflowTagsManager.vue';
 import AnnotationTagsManager from '@/components/TagsManager/AnnotationTagsManager.ee.vue';
 import UpdatesPanel from '@/components/UpdatesPanel.vue';

--- a/packages/frontend/editor-ui/src/components/Modals.vue
+++ b/packages/frontend/editor-ui/src/components/Modals.vue
@@ -131,10 +131,6 @@ import type { EventBus } from '@n8n/utils/event-bus';
 			<ImportWorkflowUrlModal />
 		</ModalRoot>
 
-		<ModalRoot :name="PERSONALIZATION_MODAL_KEY">
-			<PersonalizationModal />
-		</ModalRoot>
-
 		<ModalRoot :name="TAGS_MANAGER_MODAL_KEY">
 			<WorkflowTagsManager />
 		</ModalRoot>


### PR DESCRIPTION
## Summary

This PR removes the obsolete "questionnaire modal" component from the UI.  
The modal is no longer needed in current product design and was safely deleted from the codebase.

**How to test:**
- Launch the application.
- Ensure that the questionnaire modal no longer appears in any flow.
- Build runs without UI errors.

