### PR TITLE
feat: Add MCP Credential Sharing

### DIFF
--- a/packages/cli/src/constants/credentials.ts
+++ b/packages/cli/src/constants/credentials.ts
@@ -6,6 +6,9 @@ export const SHARED_CREDENTIAL_TYPES = [
 	'googlePalmApi',
 	'postgres',
 	'mongoDb',
+	'mcpClientApi',
+	'mcpClientSseApi',
+	'mcpClientHttpApi',
 ] as const;
 
 export type CredentialType = (typeof SHARED_CREDENTIAL_TYPES)[number];


### PR DESCRIPTION
## Summary


1. Login in n8n as owner, Add a Community Node 
2. In a workflow, add an `McpClientTool` node.Under the credentials section of the `McpClientTool`, select or create a credential , for instance if you want to create amaps mcp tool, add the api key in the credential.
3.Switch your account as user,  then you can see the shared credential in the dropdown list that owner created 

  
