### PR TITLE
feat: Send token usage to OpenMeter for LLM tracing

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
@@ -18,6 +18,8 @@ import { logAiEvent } from '@utils/helpers';
 
 const openmeter = new OpenMeter({ baseUrl: process.env.OPENMETER_URL });
 
+// const openmeter = new OpenMeter({ baseUrl: 'http://127.0.0.1:8888' });
+
 type TokensUsageParser = (llmOutput: LLMResult['llmOutput']) => {
 	completionTokens: number;
 	promptTokens: number;
@@ -221,7 +223,21 @@ export class N8nLlmTracing extends BaseCallbackHandler {
 				},
 			};
 
-			await openmeter.events.ingest([inputEvent, outputEvent]);
+			const totalEvent: Event = {
+				specversion: '1.0',
+				id: `${runId}-total`,
+				source: 'n8n',
+				type: 'prompt',
+				subject,
+				time: new Date(),
+				data: {
+					tokens: tokenUsage.totalTokens,
+					model,
+					type: 'system',
+				},
+			};
+
+			await openmeter.events.ingest([inputEvent, outputEvent, totalEvent]);
 		} catch (err) {
 			console.error('[OpenMeter] Failed to send token usage events:', err);
 		}

--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
@@ -16,7 +16,7 @@ import { NodeConnectionTypes, NodeError, NodeOperationError } from 'n8n-workflow
 
 import { logAiEvent } from '@utils/helpers';
 
-const openmeter = new OpenMeter({ baseUrl: 'http://127.0.0.1:8888' });
+const openmeter = new OpenMeter({ baseUrl: process.env.OPENMETER_URL });
 
 type TokensUsageParser = (llmOutput: LLMResult['llmOutput']) => {
 	completionTokens: number;

--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
@@ -9,11 +9,14 @@ import type {
 import type { BaseMessage } from '@langchain/core/messages';
 import type { LLMResult } from '@langchain/core/outputs';
 import { encodingForModel } from '@langchain/core/utils/tiktoken';
+import { OpenMeter, type Event } from '@openmeter/sdk';
 import { pick } from 'lodash';
 import type { IDataObject, ISupplyDataFunctions, JsonObject } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeError, NodeOperationError } from 'n8n-workflow';
 
 import { logAiEvent } from '@utils/helpers';
+
+const openmeter = new OpenMeter({ baseUrl: 'http://127.0.0.1:8888' });
 
 type TokensUsageParser = (llmOutput: LLMResult['llmOutput']) => {
 	completionTokens: number;
@@ -146,6 +149,10 @@ export class N8nLlmTracing extends BaseCallbackHandler {
 			response: { generations: output.generations },
 		};
 
+		// 	const model =
+		// response.response?.generations?.[0]?.[0]?.generationInfo?.model_name ??
+		// (runDetails.options as any)?.model_name;
+
 		// If the LLM response contains actual tokens usage, otherwise fallback to the estimate
 		if (tokenUsage.completionTokens > 0) {
 			response.tokenUsage = tokenUsage;
@@ -172,12 +179,59 @@ export class N8nLlmTracing extends BaseCallbackHandler {
 			options: runDetails.options,
 			response,
 		});
+
+		try {
+			const subject =
+				(runDetails.options as any)?.user_id ??
+				(runDetails.options as any)?.metadata?.user_id ??
+				'default-user';
+
+			// const model = (runDetails.options as any)?.model_name ?? 'unknown';
+
+			const model =
+				output.generations?.[0]?.[0]?.generationInfo?.model_name ??
+				(runDetails.options as any)?.model_name ??
+				'unknown';
+
+			const inputEvent: Event = {
+				specversion: '1.0',
+				id: `${runId}-input`,
+				source: 'n8n',
+				type: 'prompt', //  eventType = "prompt"
+				subject,
+				time: new Date(),
+				data: {
+					tokens: tokenUsage.promptTokens,
+					model,
+					type: 'input',
+				},
+			};
+
+			const outputEvent: Event = {
+				specversion: '1.0',
+				id: `${runId}-output`,
+				source: 'n8n',
+				type: 'prompt',
+				subject,
+				time: new Date(),
+				data: {
+					tokens: tokenUsage.completionTokens,
+					model,
+					type: 'output',
+				},
+			};
+
+			await openmeter.events.ingest([inputEvent, outputEvent]);
+		} catch (err) {
+			console.error('[OpenMeter] Failed to send token usage events:', err);
+		}
 	}
 
 	async handleLLMStart(llm: Serialized, prompts: string[], runId: string) {
 		const estimatedTokens = await this.estimateTokensFromStringList(prompts);
 
 		const options = llm.type === 'constructor' ? llm.kwargs : llm;
+
 		const { index } = this.executionFunctions.addInputData(this.connectionType, [
 			[
 				{

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -182,6 +182,7 @@
     "@n8n/typeorm": "0.3.20-12",
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vm2": "3.9.25",
+    "@openmeter/sdk": "1.0.0-beta.214",
     "@pinecone-database/pinecone": "4.0.0",
     "@qdrant/js-client-rest": "1.14.1",
     "@supabase/supabase-js": "2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,6 +835,9 @@ importers:
       '@n8n/vm2':
         specifier: 3.9.25
         version: 3.9.25
+      '@openmeter/sdk':
+        specifier: 1.0.0-beta.214
+        version: 1.0.0-beta.214(react@18.2.0)
       '@pinecone-database/pinecone':
         specifier: 4.0.0
         version: 4.0.0
@@ -5351,6 +5354,12 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openmeter/sdk@1.0.0-beta.214':
+    resolution: {integrity: sha512-qXuQE3K1zyC+/iDuS03W0AWMxCSDwWIYGS4+ZZckJJMFHMEalViRKvnv5zz5R2S0Cnx+2TYFml2vfL9a/85P0A==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      react: '>=18.0.0'
 
   '@opentelemetry/api-logs@0.53.0':
     resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
@@ -11928,11 +11937,17 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.14.0:
+    resolution: {integrity: sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==}
+
   openapi-sampler@1.5.1:
     resolution: {integrity: sha512-tIWIrZUKNAsbqf3bd9U1oH6JEXo8LNYuDlXw26By67EygpjT+ArFnsxxyTMjFWRfbqo5ozkvgSQDK69Gd8CddA==}
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
@@ -14318,6 +14333,9 @@ packages:
 
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+
+  vue-component-type-helpers@3.0.0:
+    resolution: {integrity: sha512-J1HtqhZIqmYoNg4SLcYVFdCdsVUkMo4Z6/Wx4sQMfY8TFIIqDmd3mS2whfBIKzAA7dHMexarwYbvtB/fOUuEsw==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -18543,6 +18561,12 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openmeter/sdk@1.0.0-beta.214(react@18.2.0)':
+    dependencies:
+      openapi-fetch: 0.14.0
+      openapi-typescript-helpers: 0.0.15
+      react: 18.2.0
+
   '@opentelemetry/api-logs@0.53.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -20227,7 +20251,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.8.2)
-      vue-component-type-helpers: 2.2.10
+      vue-component-type-helpers: 3.0.0
 
   '@supabase/auth-js@2.65.0':
     dependencies:
@@ -26921,12 +26945,18 @@ snapshots:
       - encoding
       - supports-color
 
+  openapi-fetch@0.14.0:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
   openapi-sampler@1.5.1:
     dependencies:
       '@types/json-schema': 7.0.15
       json-pointer: 0.6.2
 
   openapi-types@12.1.3: {}
+
+  openapi-typescript-helpers@0.0.15: {}
 
   option@0.2.4: {}
 
@@ -29650,6 +29680,8 @@ snapshots:
   vue-component-type-helpers@2.1.10: {}
 
   vue-component-type-helpers@2.2.10: {}
+
+  vue-component-type-helpers@3.0.0: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.8.2)):
     dependencies:


### PR DESCRIPTION
## Summary

This PR integrates OpenMeter into the LLM tracing pipeline.
It sends token usage data (prompt and completion tokens) to the OpenMeter API for every LLM run, enabling token tracking and analytics across input/output
OpenMeter supports token tracking for text, images, and audio.
1.To verify that token data is correctly sent and ingested：
Clone and run the  the repo named openmeter-web:
cd openmeter-GUI  node server.js
cd openmeter-GUI/openmeter-frontend pnpm start
2.Open http://localhost:3000/ in your browser
3.Select today’s date in the UI — you'll see the token usage data appear.
4.You can also browse historical usage by selecting any previous date.

